### PR TITLE
update: cleanup files in build and arch cases

### DIFF
--- a/bazel/go/Dockerfile
+++ b/bazel/go/Dockerfile
@@ -5,7 +5,7 @@ ADD get_arch /get_arch
 ADD fetch_migrate /fetch_migrate
 
 RUN /fetch_migrate
-RUN rm /fetch_migrate
+RUN rm /fetch_migrate /get_arch
 RUN dnf update -y && dnf install -y vim-common && dnf clean all
 
 USER 1000

--- a/bazel/go/get_arch
+++ b/bazel/go/get_arch
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 case "$(uname -m)" in
-    x86_64 | amd64)
+    x86_64)
         echo -n "amd64"
         ;;
-    arm64 | aarch64)
+    aarch64)
         echo -n "arm64"
         ;;
     *)

--- a/build/get_arch
+++ b/build/get_arch
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 case "$(uname -m)" in
-    x86_64 | amd64)
+    x86_64)
         echo -n "amd64"
         ;;
-    arm64 | aarch64)
+    aarch64)
         echo -n "arm64"
         ;;
     *)

--- a/build/rhel.Dockerfile
+++ b/build/rhel.Dockerfile
@@ -6,7 +6,7 @@ ENV TINI_VERSION v0.19.0
 RUN curl -o /tini -L "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$(/get_arch)"
 RUN chmod +x /tini
 
-RUN rm -rf /etc/yum.repos.d/*.repo
+RUN rm -rf /etc/yum.repos.d/*.repo /get_arch
 ADD epelkey.gpg /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9
 ADD rhel.repo /etc/yum.repos.d/rhel.repo
 


### PR DESCRIPTION
- cleanup get_arch in build process
- remove unnecessary arch option, default fall back to "uname -m"